### PR TITLE
add Cache-Control for putObject api

### DIFF
--- a/lib/obsModel.js
+++ b/lib/obsModel.js
@@ -1650,6 +1650,10 @@ const operations = {
 				'location' : 'header',
 				'sentAs' : 'Content-Type'
 			},
+			'CacheControl': {
+				'location': 'header',
+				'sentAs': 'Cache-Control'
+			},
 			'Offset' : {
 				'type' : 'plain'
 			},


### PR DESCRIPTION
修复： putObject里面不能设置对象CacheControl属性